### PR TITLE
Possessive of "it" has no apostrophe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ def hello_t(array)
 end
 ```
 
-Here, we tell our method to return the original array simply by having that array be the last line of the method. Whatever is evaluated last in a method will be it's return value. If you run the test again, you should be passing. 
+Here, we tell our method to return the original array simply by having that array be the last line of the method. Whatever is evaluated last in a method will be its return value. If you run the test again, you should be passing. 
 
 
 ### Advanced: Defining a method to optionally take a block


### PR DESCRIPTION
Corrected typo